### PR TITLE
Patch feedjira to recognize xmlns="https://www.w3.org/2005/Atom" as Atom

### DIFF
--- a/config/initializers/patch_feedjira.rb
+++ b/config/initializers/patch_feedjira.rb
@@ -1,0 +1,8 @@
+class Feedjira::Parser::Atom
+  # monkey-patch to allow xmlns=https://www.w3.org/2005/Atom , even though
+  # the `https` actually violates Atom as not a good namespace,
+  # https://idiosyncratic-ruby.com/feed.xml does it anyway, let's allow it.
+  def self.able_to_parse?(xml)
+    %r{\<feed[^\>]+xmlns\s?=\s?[\"\'](http(s?)://www\.w3\.org/2005/Atom|http://purl\.org/atom/ns\#)[\"\'][^\>]*\>} =~ xml # rubocop:disable Metrics/LineLength
+  end
+end


### PR DESCRIPTION
This is actually illegal, the Atom spec says namespace should be http:// not https://.

But https://idiosyncratic-ruby.com/feed.xml does it, let's recognize it anyway.